### PR TITLE
Don't lowercase projectRootPath to fix alwaysInclude functionality

### DIFF
--- a/.changeset/ten-seas-grin.md
+++ b/.changeset/ten-seas-grin.md
@@ -1,0 +1,5 @@
+---
+'ts-scope-trimmer-plugin': patch
+---
+
+Fix alwaysInclude functionality

--- a/src/config.ts
+++ b/src/config.ts
@@ -71,7 +71,7 @@ const getProjectRootPath = (info: ts.server.PluginCreateInfo): ProjectRootPath =
 	const [anyOpenFilePath, projectRootPath] = anyOpenFile
 
 	if (projectRootPath) {
-		return projectRootPath.toLowerCase()
+		return projectRootPath
 	}
 
 	// projectRootPath can be undefined in JetBrains products, e.g. WebStorm.
@@ -88,7 +88,7 @@ const getProjectRootPath = (info: ts.server.PluginCreateInfo): ProjectRootPath =
 			.toString()
 			.trim()
 
-		return gitRoot.toLowerCase()
+		return gitRoot
 	} catch (error) {
 		debug({
 			config: info.config,


### PR DESCRIPTION
After https://github.com/miroapp/ts-scope-trimmer-plugin/pull/6, `alwaysInclude` became broken